### PR TITLE
Adds config for Github Actions and Coveralls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: Tests
+
+on:
+  push:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build_and_test:
+    name: Rust project - latest
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolchain:
+          - stable
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
+      - name: Run cargo-tarpaulin
+        uses: actions-rs/tarpaulin@v0.1
+      - name: Coveralls GitHub Action
+        uses: coverallsapp/github-action@v1.1.2
+        with:
+          github-token: ${{ github.token }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+/coverage
+*.profraw

--- a/tarpaulin.toml
+++ b/tarpaulin.toml
@@ -1,0 +1,6 @@
+[test_config]
+skip-clean = true
+exclude-files = ["target"]
+target-dir = "coverage"
+out = ["Lcov"]
+output-dir = "coverage"


### PR DESCRIPTION
In order to get better insight into test coverage, this commit adds configuration files for Github Actions and Tarpualin.

In addition, the Github Actions submits coverage data to Coveralls.