### PR TITLE
Changes any mention of the center of a model to anchor or world_anchor

### DIFF
--- a/examples/models/air_square.model
+++ b/examples/models/air_square.model
@@ -1,6 +1,6 @@
 SKIN
-center='c'
-center_replacement='-'
+anchor='c'
+anchor_replacement='-'
 air='-'
 name='Air Square'
 strata='100'

--- a/examples/models/square.model
+++ b/examples/models/square.model
@@ -1,7 +1,7 @@
 SKIN
 +- This line will not be run because it has "+- " in it
-center='c'
-center_replacement='-'
+anchor='c'
+anchor_replacement='-'
 air='-'
 name='Square'
 strata='0'

--- a/examples/models/wall.model
+++ b/examples/models/wall.model
@@ -1,6 +1,6 @@
 SKIN
-center='c'
-center_replacement='|'
+anchor='c'
+anchor_replacement='|'
 air='-'
 name='Wall'
 strata='100'

--- a/src/models/errors.rs
+++ b/src/models/errors.rs
@@ -5,9 +5,8 @@ use std::ffi::OsString;
 /// This is the list of possible errors that could occurr
 /// while handling models.
 pub enum ModelError {
-  /// While creating the model, no center point
-  /// was found.
-  NoCenter,
+  /// While creating the model, no anchor point was found.
+  NoAnchor,
 
   /// While creating the model, no every row
   /// contained the same amount of characters.
@@ -34,10 +33,10 @@ pub enum ModelError {
   /// When internal model data was attempted to be changed with an model hash that doesn't exist.
   ModelDoesntExist,
 
-  /// There were multiple centers found in the object's appearance and or hitbox.
+  /// There were multiple anchors found in the object's appearance and or hitbox.
   ///
-  /// Returns the list of indexes the center was found in.
-  MultipleCentersFound(Vec<usize>),
+  /// Returns the list of indexes the anchor was found in.
+  MultipleAnchorsFound(Vec<usize>),
 
   /// Contains the types of errors that can happen when parsing a model file.
   ModelCreationError(ModelCreationError),

--- a/src/models/model_file_parser.rs
+++ b/src/models/model_file_parser.rs
@@ -8,8 +8,8 @@ pub struct ModelParser;
 
 #[derive(Default, Debug)]
 struct ModelDataBuilder {
-  center: Option<char>,
-  center_replacement: Option<char>,
+  anchor: Option<char>,
+  anchor_replacement: Option<char>,
   air: Option<char>,
   name: Option<String>,
   strata: Option<Strata>,
@@ -46,8 +46,8 @@ impl ModelDataBuilder {
   fn build_sprite(&self) -> Result<Sprite, ModelError> {
     let skin = Skin::new(
       self.appearance.as_ref().unwrap(),
-      self.center.unwrap(),
-      self.center_replacement.unwrap(),
+      self.anchor.unwrap(),
+      self.anchor_replacement.unwrap(),
       self.air.unwrap(),
     )?;
 
@@ -56,9 +56,9 @@ impl ModelDataBuilder {
 
   fn build_hitbox_data(&self) -> HitboxCreationData {
     let hitbox_shape = &self.hitbox_dimensions.as_ref().unwrap();
-    let center_character = self.center.unwrap();
+    let anchor_character = self.anchor.unwrap();
 
-    HitboxCreationData::new(hitbox_shape, center_character)
+    HitboxCreationData::new(hitbox_shape, anchor_character)
   }
 
   /// Checks if every field in the given ModelDataBuilder exists.
@@ -73,12 +73,12 @@ impl ModelDataBuilder {
   fn check_if_all_data_exists(&self) -> Result<(), ModelCreationError> {
     let mut error_list = vec![];
 
-    if self.center.is_none() {
-      error_list.push("Center Character".to_string());
+    if self.anchor.is_none() {
+      error_list.push("Anchor Character".to_string());
     }
 
-    if self.center_replacement.is_none() {
-      error_list.push("Center Replacement Character".to_string());
+    if self.anchor_replacement.is_none() {
+      error_list.push("Anchor Replacement Character".to_string());
     }
 
     if self.air.is_none() {
@@ -182,8 +182,8 @@ impl ModelParser {
         match section {
           Section::Skin => {
             // Contents
-            // - center
-            // - center_replacement
+            // - anchor
+            // - anchor_replacement
             // - air
             // - name
             // - strata
@@ -233,16 +233,16 @@ impl ModelParser {
     });
 
     match data_type.to_lowercase().trim() {
-      "center" => {
-        let center_character = Self::contents_to_char(row_contents, line_number)?;
+      "anchor" => {
+        let anchor_character = Self::contents_to_char(row_contents, line_number)?;
 
-        model_data_builder.center = Some(center_character);
+        model_data_builder.anchor = Some(anchor_character);
       }
 
-      "center_replacement" => {
-        let center_replacement = Self::contents_to_char(row_contents, line_number)?;
+      "anchor_replacement" => {
+        let anchor_replacement = Self::contents_to_char(row_contents, line_number)?;
 
-        model_data_builder.center_replacement = Some(center_replacement);
+        model_data_builder.anchor_replacement = Some(anchor_replacement);
       }
 
       "air" => {

--- a/src/models/sprites.rs
+++ b/src/models/sprites.rs
@@ -14,17 +14,17 @@ pub struct Sprite {
 
 /// The Skin is how an model will appear on the screen.
 ///
-/// When creating a skin's shape, center and air characters will need to be designated.
-/// The center character will be replaced with the 'center_replacement_character' field when
+/// When creating a skin's shape, anchor and air characters will need to be designated.
+/// The anchor character will be replaced with the 'anchor_replacement_character' field when
 /// building the shape of the Skin.
 #[derive(Debug, PartialEq, Eq)]
 pub struct Skin {
   pub shape: String,
-  pub center_character: char,
-  pub center_replacement_character: char,
+  pub anchor_character: char,
+  pub anchor_replacement_character: char,
   pub air_character: char,
   /// Doesn't count new lines
-  center_character_index: usize,
+  anchor_character_index: usize,
 }
 
 impl Sprite {
@@ -35,8 +35,8 @@ impl Sprite {
     Ok(Self { skin })
   }
 
-  pub fn get_center_character_index(&self) -> usize {
-    self.skin.center_character_index
+  pub fn get_anchor_character_index(&self) -> usize {
+    self.skin.anchor_character_index
   }
 
   /// Returns a reference to the skin's shape
@@ -49,63 +49,46 @@ impl Sprite {
     &mut self.skin.shape
   }
 
-  // /// Returns a reference to the relative points of the hitbox to
-  // /// the designated center point of the model's skin.
-  // pub fn get_hitbox(&self) -> &Vec<(isize, isize)> {
-  //   &self.hitbox
-  // }
-
-  // /// Replaces the model's hitbox with a new one
-  // pub fn change_hitbox(&mut self, new_hitbox: HitboxCreationData) -> Result<(), ModelError> {
-  //   match new_hitbox.get_hitbox_data() {
-  //     Ok(hitbox_data) => self.hitbox = hitbox_data,
-  //     Err(error) => return Err(error),
-  //   }
-  //
-  //   Ok(())
-  // }
-
   pub fn air_character(&self) -> char {
     self.skin.air_character
   }
 }
 
 impl Skin {
-  // MODEL CREATION WILL CHANGE TO A FILE FORMAT
   pub fn new(
     shape: &str,
-    center_character: char,
-    center_replacement_character: char,
+    anchor_character: char,
+    anchor_replacement_character: char,
     air_character: char,
   ) -> Result<Self, ModelError> {
     let cleaned_shape = shape.replace('\n', "");
-    let center_character_index = cleaned_shape
+    let anchor_character_index = cleaned_shape
       .chars()
-      .position(|pixel| pixel == center_character);
+      .position(|pixel| pixel == anchor_character);
 
-    match center_character_index {
-      None => Err(ModelError::NoCenter),
-      Some(center_character_index) => Ok(Self {
+    match anchor_character_index {
+      None => Err(ModelError::NoAnchor),
+      Some(anchor_character_index) => Ok(Self {
         shape: shape.to_string(),
-        center_character,
-        center_replacement_character,
+        anchor_character,
+        anchor_replacement_character,
         air_character,
-        center_character_index,
+        anchor_character_index,
       }),
     }
   }
 
-  /// Replaces the center character in the skin's shape with the given
+  /// Replaces the anchor character in the skin's shape with the given
   /// replacement character.
   fn fix_skin(&mut self) {
     self.shape = self.shape.replace(
-      &self.center_character.to_string(),
-      &self.center_replacement_character.to_string(),
+      &self.anchor_character.to_string(),
+      &self.anchor_replacement_character.to_string(),
     );
   }
 
-  pub fn get_center_character_index(&self) -> usize {
-    self.center_character_index
+  pub fn get_anchor_character_index(&self) -> usize {
+    self.anchor_character_index
   }
 }
 
@@ -130,11 +113,11 @@ mod skin_logic {
 //   use super::*;
 //
 //   #[test]
-//   fn valid_data_center_is_hitbox() {
+//   fn valid_data_anchor_is_hitbox() {
 //     let hitbox = get_hitbox_data(true);
 //
 //     // xxx
-//     //  x  < this x is the center character
+//     //  x  < this x is the anchor character
 //     let expected_hitbox_data = Ok(vec![(-1, -1), (0, -1), (1, -1), (0, 0)]);
 //
 //     let hitbox_data = hitbox.get_hitbox_data();
@@ -143,11 +126,11 @@ mod skin_logic {
 //   }
 //
 //   #[test]
-//   fn valid_data_center_is_not_hitbox() {
+//   fn valid_data_anchor_is_not_hitbox() {
 //     let hitbox = get_hitbox_data(false);
 //
 //     // xxx
-//     //  c  < this center character is not apart of the hitbox
+//     //  c  < this anchor character is not apart of the hitbox
 //     let expected_hitbox_data = Ok(vec![(-1, -1), (0, -1), (1, -1)]);
 //
 //     let hitbox_data = hitbox.get_hitbox_data();
@@ -168,7 +151,7 @@ mod skin_logic {
 //   }
 //
 //   #[test]
-//   fn no_center_character() {
+//   fn no_anchor_character() {
 //     let mut hitbox = get_hitbox_data(true);
 //     hitbox.shape = "".to_string();
 //
@@ -179,11 +162,11 @@ mod skin_logic {
 //     assert_eq!(hitbox_data, expected_error);
 //   }
 
-// fn get_hitbox_data(center_is_hitbox: bool) -> HitboxCreationData {
+// fn get_hitbox_data(anchor_is_hitbox: bool) -> HitboxCreationData {
 //   let shape = "xyz\n-c-";
-//   let center_character = 'c';
+//   let anchor_character = 'c';
 //   let air_character = '-';
 //
-//   HitboxCreationData::new(shape, center_character, air_character, center_is_hitbox)
+//   HitboxCreationData::new(shape, anchor_character, air_character, anchor_is_hitbox)
 // }
 // }

--- a/src/models/traits.rs
+++ b/src/models/traits.rs
@@ -8,7 +8,7 @@ pub use model_macros::Model;
 pub use std::sync::{Arc, Mutex, RwLock};
 
 pub trait Model {
-  /// Returns the center position of the model.
+  /// Returns the world placement of the model.
   fn get_position(&self) -> usize;
   /// Returns the very top left position of the model.
   fn get_top_left_position(&self) -> usize;
@@ -29,12 +29,6 @@ pub trait Model {
   fn get_sprite(&self) -> String;
   /// Changes the appearance of the model.
   fn change_sprite(&mut self, new_model: String);
-
-  // /// Returns the list of relative points around the model's center that act
-  // /// as the model's hitbox.
-  // fn get_hitbox(&self) -> Vec<(isize, isize)>;
-  // ///
-  // fn change_hitbox(&mut self, new_hitbox_model: HitboxCreationData) -> Result<(), ModelError>;
 
   /// Returns a copy of the model's unique hash.
   fn get_unique_hash(&self) -> u64;

--- a/src/screen/screen_data.rs
+++ b/src/screen/screen_data.rs
@@ -227,8 +227,8 @@ mod tests {
   use crate::models::hitboxes::HitboxCreationData;
 
   const SHAPE: &str = "x-x\nxcx\nx-x";
-  const CENTER_CHAR: char = 'c';
-  const CENTER_REPLACEMENT_CHAR: char = '-';
+  const ANCHOR_CHAR: char = 'c';
+  const ANCHOR_REPLACEMENT_CHAR: char = '-';
   const AIR_CHAR: char = '-';
 
   #[test]
@@ -325,7 +325,7 @@ mod tests {
   }
 
   fn get_skin() -> Skin {
-    Skin::new(SHAPE, CENTER_CHAR, CENTER_REPLACEMENT_CHAR, AIR_CHAR).unwrap()
+    Skin::new(SHAPE, ANCHOR_CHAR, ANCHOR_REPLACEMENT_CHAR, AIR_CHAR).unwrap()
   }
 
   fn get_hitbox() -> HitboxCreationData {

--- a/tests/model_tests.rs
+++ b/tests/model_tests.rs
@@ -1,8 +1,8 @@
 use ascii_engine::prelude::*;
 
 const SHAPE: &str = "x-x\nxcx\nx-x";
-const CENTER_CHAR: char = 'c';
-const CENTER_REPLACEMENT_CHAR: char = '-';
+const ANCHOR_CHAR: char = 'c';
+const ANCHOR_REPLACEMENT_CHAR: char = '-';
 const AIR_CHAR: char = '-';
 const MODEL_NAME: &str = "rectangle";
 
@@ -11,20 +11,20 @@ mod skin_logic {
   use super::*;
 
   #[test]
-  fn center_character_index_check() {
+  fn anchor_character_index_check() {
     let skin = get_skin();
 
-    let expected_center_character_index = 4;
+    let expected_anchor_character_index = 4;
 
     assert_eq!(
-      expected_center_character_index,
-      skin.get_center_character_index()
+      expected_anchor_character_index,
+      skin.get_anchor_character_index()
     );
   }
 
   #[test]
-  fn no_center_on_shape() {
-    let skin_result = Skin::new("xxx\nxxx", CENTER_CHAR, CENTER_REPLACEMENT_CHAR, AIR_CHAR);
+  fn no_anchor_on_shape() {
+    let skin_result = Skin::new("xxx\nxxx", ANCHOR_CHAR, ANCHOR_REPLACEMENT_CHAR, AIR_CHAR);
 
     assert!(skin_result.is_err());
   }
@@ -35,14 +35,14 @@ mod sprite_logic {
   use super::*;
 
   #[test]
-  fn center_character_index_check() {
+  fn anchor_character_index_check() {
     let sprite = get_sprite();
 
     let expected_index = 4;
 
-    let center_skin_index = sprite.get_center_character_index();
+    let anchor_skin_index = sprite.get_anchor_character_index();
 
-    assert_eq!(center_skin_index, expected_index);
+    assert_eq!(anchor_skin_index, expected_index);
   }
 
   #[test]
@@ -50,8 +50,8 @@ mod sprite_logic {
     let sprite = get_sprite();
 
     let expected_skin = SHAPE.replace(
-      &CENTER_CHAR.to_string(),
-      &CENTER_REPLACEMENT_CHAR.to_string(),
+      &ANCHOR_CHAR.to_string(),
+      &ANCHOR_REPLACEMENT_CHAR.to_string(),
     );
 
     let sprite_skin = sprite.get_shape();
@@ -64,8 +64,8 @@ mod sprite_logic {
     let mut sprite = get_sprite();
 
     let mut expected_skin = SHAPE.replace(
-      &CENTER_CHAR.to_string(),
-      &CENTER_REPLACEMENT_CHAR.to_string(),
+      &ANCHOR_CHAR.to_string(),
+      &ANCHOR_REPLACEMENT_CHAR.to_string(),
     );
 
     let sprite_skin = sprite.get_mut_shape();
@@ -79,7 +79,7 @@ mod sprite_logic {
     // let sprite = get_sprite(true);
     //
     // // xxx
-    // //  x  < this x is the center character
+    // //  x  < this x is the anchor character
     // let expected_hitbox_data = vec![(-1, -1), (0, -1), (1, -1), (0, 0)];
     //
     // let hitbox_data = sprite.get_hitbox();
@@ -104,7 +104,7 @@ mod sprite_logic {
 
   #[test]
   #[ignore]
-  /// Has no center character.
+  /// Has no anchor character.
   fn change_hitbox_invalid_new_hitbox() {
     // let mut sprite = get_sprite(true);
     // let new_hitbox = HitboxCreationData::new("xxxxx\n-----", 'c', '-', false);
@@ -237,15 +237,15 @@ mod model_data_logic {
     }
 
     #[test]
-    fn get_center_frame_index() {
+    fn get_anchor_frame_index() {
       let (x, y) = (10, 10);
       let model_data = get_model_data((x, y));
 
-      let expected_current_center_frame_index = ((CONFIG.grid_width + 1) as usize * y) + x;
+      let expected_current_anchor_frame_index = ((CONFIG.grid_width + 1) as usize * y) + x;
 
       assert_eq!(
         model_data.get_model_position(),
-        expected_current_center_frame_index
+        expected_current_anchor_frame_index
       );
     }
 
@@ -363,7 +363,7 @@ mod model_data_logic {
 
     #[test]
     #[ignore]
-    /// Has no center character.
+    /// Has no anchor character.
     fn change_hitbox_invalid_new_hitbox() {
       // let mut model_data = get_model_data((5, 5), true);
       // let new_hitbox = HitboxCreationData::new("xxxxx\n-----", 'c', '-', false);
@@ -392,7 +392,7 @@ mod model_data_logic {
     //   let sprite = get_sprite();
     //   let model_position = model_data.get_model_position();
     //
-    //   let relative_coordinates = get_0_0_relative_to_center(&sprite);
+    //   let relative_coordinates = get_0_0_relative_to_anchor(&sprite);
     //
     //   let true_width = CONFIG.grid_width as isize + 1;
     //
@@ -400,17 +400,17 @@ mod model_data_logic {
     //     as usize
     // }
     //
-    // fn get_0_0_relative_to_center(sprite: &Sprite) -> (isize, isize) {
+    // fn get_0_0_relative_to_anchor(sprite: &Sprite) -> (isize, isize) {
     //   let sprite_rows: Vec<&str> = sprite.get_shape().split('\n').collect();
     //   let sprite_width = sprite_rows[0].chars().count() as isize;
     //
-    //   let skin_center_index = sprite.get_center_character_index() as isize;
-    //   let skin_center_coordinates = (
-    //     skin_center_index % sprite_width,
-    //     skin_center_index / sprite_width,
+    //   let skin_anchor_index = sprite.get_anchor_character_index() as isize;
+    //   let skin_anchor_coordinates = (
+    //     skin_anchor_index % sprite_width,
+    //     skin_anchor_index / sprite_width,
     //   );
     //
-    //   (-skin_center_coordinates.0, -skin_center_coordinates.1)
+    //   (-skin_anchor_coordinates.0, -skin_anchor_coordinates.1)
     // }
   }
 }
@@ -437,7 +437,7 @@ fn get_sprite() -> Sprite {
 }
 
 fn get_skin() -> Skin {
-  Skin::new(SHAPE, CENTER_CHAR, CENTER_REPLACEMENT_CHAR, AIR_CHAR).unwrap()
+  Skin::new(SHAPE, ANCHOR_CHAR, ANCHOR_REPLACEMENT_CHAR, AIR_CHAR).unwrap()
 }
 
 fn get_hitbox() -> HitboxCreationData {

--- a/tests/screen_tests.rs
+++ b/tests/screen_tests.rs
@@ -2,8 +2,8 @@ use ascii_engine::prelude::*;
 use std::sync::{Arc, Mutex};
 
 const SHAPE: &str = "x-x\nxcx\nx-x";
-const CENTER_CHAR: char = 'c';
-const CENTER_REPLACEMENT_CHAR: char = '-';
+const ANCHOR_CHAR: char = 'c';
+const ANCHOR_REPLACEMENT_CHAR: char = '-';
 const AIR_CHAR: char = '-';
 const MODEL_NAME: &str = "rectangle";
 
@@ -110,7 +110,7 @@ fn get_sprite() -> Sprite {
 }
 
 fn get_skin() -> Skin {
-  Skin::new(SHAPE, CENTER_CHAR, CENTER_REPLACEMENT_CHAR, AIR_CHAR).unwrap()
+  Skin::new(SHAPE, ANCHOR_CHAR, ANCHOR_REPLACEMENT_CHAR, AIR_CHAR).unwrap()
 }
 
 fn get_hitbox() -> HitboxCreationData {


### PR DESCRIPTION
In order to have a more consistent meaning as to what the center was, this commit changes any mention of "center" to "anchor" or "world_anchor".

When talking about the character that dictated an achor from the hitbox to the skin, "center" was replaced with "anchor".
When talking about the relative distance of the anchor to a model's top left index in a frame, "center" was changed to something along the lines of "world_placement_anchor".