### PR TITLE
Fixes a bug with printing

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,6 @@
 log_level = "debug"
 log_file_message_size = "long"
-empty_pixel = " "
+empty_pixel = "`"
 tick_duration = 12
 grid_width = 175
 grid_height = 40

--- a/examples/model_tests/main.rs
+++ b/examples/model_tests/main.rs
@@ -84,10 +84,8 @@ impl Square {
               .unwrap();
 
             let connected_pad_position = connected_teleport_pad.get_position();
-            let mut connected_pad_position =
+            let connected_pad_position =
               connected_pad_position.index_to_coordinates((CONFIG.grid_width + 1) as usize);
-            // // Move 1 down to prevent infinite teleportation.
-            // connected_pad_position.1 += 1;
 
             let collision_list = initial_square.move_to(connected_pad_position);
 

--- a/examples/model_tests/screen_config.rs
+++ b/examples/model_tests/screen_config.rs
@@ -80,7 +80,9 @@ impl ScreenConfig {
       Ok((pad_1_hash, pad_2_hash))
     } else {
       // maybe make an error called "ModelError::Other("What went wrong")"
-      Err(ModelError::ModelDoesntExist)
+      Err(ModelError::Other(
+        "Attempted to add teleport pads that weren't connected".to_string(),
+      ))
     }
   }
 

--- a/src/models/errors.rs
+++ b/src/models/errors.rs
@@ -38,6 +38,11 @@ pub enum ModelError {
   /// Returns the list of indexes the anchor was found in.
   MultipleAnchorsFound(Vec<usize>),
 
+  /// When something went wrong but it wasn't enough to warrent it's own type.
+  ///
+  /// Contains a description of what went wrong.
+  Other(String),
+
   /// Contains the types of errors that can happen when parsing a model file.
   ModelCreationError(ModelCreationError),
 }

--- a/src/screen/errors.rs
+++ b/src/screen/errors.rs
@@ -9,4 +9,6 @@ pub enum ScreenError {
   NoExistingModels,
 
   PrinterNotStarted,
+
+  PrinterAlreadyStarted,
 }

--- a/src/screen/screen_data.rs
+++ b/src/screen/screen_data.rs
@@ -98,8 +98,6 @@ impl ScreenData {
     if !self.printer_started {
       return Err(ScreenError::PrinterNotStarted);
     } else if self.first_print {
-      println!("{}", "\n".repeat(CONFIG.grid_height as usize + 10));
-
       self.first_print = false;
     }
 
@@ -126,11 +124,18 @@ impl ScreenData {
   where
     T: std::fmt::Display + std::ops::Deref,
   {
-    print!("\x1B[0;0H");
+    print!("\x1B[1;1H");
     println!("{message}");
   }
 
   pub fn start_printer(&mut self) -> Result<(), ScreenError> {
+    if self.printer_started {
+      return Err(ScreenError::PrinterAlreadyStarted);
+    }
+
+    println!("{}", termion::clear::All);
+    println!("{}", "\n".repeat(CONFIG.grid_height as usize + 10));
+
     if let Err(printing_error) = self.printer.manual_set_origin() {
       return Err(ScreenError::PrintingError(printing_error));
     }


### PR DESCRIPTION
This commit fixes a bug where origin was being set incorrectly. The adjustment newlines were being printed after origin was set since the new "start_printer" method moved where that happened.