### PR TITLE
Implements a way to remove a model from the internal storage

### DIFF
--- a/examples/model_tests/screen_config.rs
+++ b/examples/model_tests/screen_config.rs
@@ -40,6 +40,18 @@ impl ScreenConfig {
     Ok(square_hash)
   }
 
+  /// Removes any mention of the square pertaining to the given hash.
+  ///
+  /// Returns the removed square, if it didn't exist returns None.
+  #[allow(dead_code)]
+  pub fn remove_square(&mut self, key: &u64) -> Option<Square> {
+    let square = self.models.square_list.remove(key)?;
+
+    self.screen.remove_model(key)?;
+
+    Some(square)
+  }
+
   /// Gets a mutable reference to the square of the given unique hash.
   ///
   /// Returns None if the model didn't exist.

--- a/src/screen/screen_data.rs
+++ b/src/screen/screen_data.rs
@@ -307,6 +307,17 @@ impl ScreenData {
     self.model_data.write().unwrap().insert(model_data)
   }
 
+  /// Removes the ModelData of the given key.
+  ///
+  /// Returns The ModelData if it existed, otherwise returns None.
+  ///
+  /// # Errors (yes there's technically an error)
+  ///
+  /// Returns None when any existing model somehow has an impossible strata.
+  pub fn remove_model(&mut self, key: &u64) -> Option<ModelData> {
+    self.model_data.write().unwrap().remove(key)
+  }
+
   /// Places the appearance of the model in the given frame.
   fn apply_model_in_frame(model: ModelData, current_frame: &mut String) {
     let model_frame_position = model.top_left();


### PR DESCRIPTION
In order to have a way to remove internally stored models, this commit adds the ``remove_model()`` method to ScreenData and InternalModels. This method will remove any mention of a model of the passed in hash. If the model never existed internally to begin with, it just returns nothing.
If the model did exist, it returns the ModelData that was held internally.